### PR TITLE
Release 0.2.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 name = "htb"
 repository = "https://github.com/pacak/htb-rs"
-version = "0.2.3"
+version = "0.2.4"
 categories = ["algorithms", "network-programming", "concurrency"]
 keywords = ["rate-limiting", "rate-limit", "htb", "token-bucket"]
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [0.2.4] - 2024-10-29
+- ::available method to query the remaining tokens
+
 ## [0.2.3] - 2023-12-11
 - optional borsh support
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -331,6 +331,11 @@ where
         self.state[usize::from(label)].value >= self.unit_cost
     }
 
+    /// Shows how many tokens are available at
+    pub fn available(&self, label: T) -> u64 {
+        self.state[usize::from(label)].value / self.unit_cost
+    }
+
     /// Check if there's at least `cnt` tokens available at index `T`
     ///
     /// See also [`peek`][Self::peek]
@@ -423,12 +428,17 @@ mod tests {
     #[test]
     fn it_works() {
         let mut htb = sample_htb();
+        assert_eq!(htb.available(Rate::Hedge), 10);
         assert!(htb.take_n(Rate::Hedge, 4));
+        assert_eq!(htb.available(Rate::Hedge), 6);
         assert!(htb.take_n(Rate::Hedge, 4));
+        assert_eq!(htb.available(Rate::Hedge), 2);
         assert!(htb.take_n(Rate::Hedge, 2));
+        assert_eq!(htb.available(Rate::Hedge), 0);
         assert!(!htb.take_n(Rate::Hedge, 1));
         htb.advance(Duration::from_millis(1));
         assert!(htb.peek_n(Rate::Hedge, 1));
+        assert_eq!(htb.available(Rate::Hedge), 1);
         assert!(!htb.peek_n(Rate::Hedge, 2));
         assert!(htb.take(Rate::Hedge));
         assert!(!htb.take(Rate::Hedge));


### PR DESCRIPTION
Add `HTB::available` method that lists tokens remaining in a bucket